### PR TITLE
ci: auto-deploy cloud code to production on merge to master

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,74 @@
+name: Deploy to Back4App
+
+# Deploys cloud code to the production Back4App app on merge to master.
+# Gated on the Jest suite passing first. Requires two repo secrets:
+#   B4A_ACCOUNT_KEY       — a Back4App account key (Dashboard → Account Keys)
+#   B4A_PRODUCTION_APP_ID — the production app's Application ID
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  PARSE_ENV: "dev"
+  PARSE_APP_ID: "myAppId"
+  PARSE_JAVASCRIPT_KEY: "_PLACEHOLDER_"
+  PARSE_SERVER_URL: "http://localhost:1337/parse"
+  PUENTE_ENV: "dev"
+  PUENTE_SMS_EMAIL_API_URL: "http://puentes-messaging-microservice.com"
+  PUENTE_MANAGE_URL: "https://sample-puente-manage.app/"
+  SLACK_TOKEN: ""
+  SLACK_DEV_CHANNEL: ""
+  SLACK_PROD_CHANNEL: ""
+
+jobs:
+  # Gate: never deploy code that fails the suite, even on a direct push to master
+  test:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+      - run: npm install
+      - run: npm run lint
+      - run: npm test -- --no-coverage
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install b4a CLI
+        run: |
+          curl -sL -o /usr/local/bin/b4a \
+            https://github.com/back4app/parse-cli/releases/download/release_3.3.1/b4a_linux
+          chmod +x /usr/local/bin/b4a
+          b4a version
+
+      - name: Configure Back4App account key
+        env:
+          B4A_ACCOUNT_KEY: ${{ secrets.B4A_ACCOUNT_KEY }}
+        run: |
+          if [ -z "$B4A_ACCOUNT_KEY" ]; then
+            echo "::error::B4A_ACCOUNT_KEY secret is not set"; exit 1
+          fi
+          mkdir -p "$HOME/.back4app"
+          printf 'machine parsecli.back4app.com\n\tlogin default\n\tpassword %s\n' \
+            "$B4A_ACCOUNT_KEY" > "$HOME/.back4app/netrc"
+          chmod 600 "$HOME/.back4app/netrc"
+
+      - name: Link production app
+        env:
+          B4A_PRODUCTION_APP_ID: ${{ secrets.B4A_PRODUCTION_APP_ID }}
+        run: |
+          if [ -z "$B4A_PRODUCTION_APP_ID" ]; then
+            echo "::error::B4A_PRODUCTION_APP_ID secret is not set"; exit 1
+          fi
+          printf '{\n  "applications": {\n    "production": {\n      "applicationId": "%s"\n    }\n  }\n}\n' \
+            "$B4A_PRODUCTION_APP_ID" > .parse.local
+
+      - name: Deploy cloud code
+        run: b4a deploy production -d "GHA ${GITHUB_SHA::7}"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ To get ramped onto the project with Back4App these following steps must be taken
 - Run `b4a add` and choose the project you've created in Back4app Web Service
 - Run `b4a develop` to see changes live with Back4app Web Service
 
+### Deployment
+
+Production deploys are **automated**: merging to `master` runs the Jest suite
+and, if it passes, deploys cloud code to the production Back4App app
+(`.github/workflows/deploy.yaml`). No manual step is needed.
+
+Two repository secrets drive it (Settings → Secrets and variables → Actions):
+
+- `B4A_ACCOUNT_KEY` — a Back4App account key (Dashboard → your avatar →
+  Account Keys → create)
+- `B4A_PRODUCTION_APP_ID` — the production app's Application ID
+
+**Manual deploy** (fallback, e.g. to staging) still works with the CLI from the
+project root, once `b4a add` has linked the target app:
+
+```
+b4a deploy production   # or: staging
+```
+
 ## Testing
 
 ### Jest


### PR DESCRIPTION
## What

Replaces the manual `b4a deploy` step (previously in package.json / run by hand) with a GitHub Action: **merge to `master` → run Jest → if green, deploy `cloud/` to the production Back4App app.**

This is the gap that let the offline client-pointer orphaning bug (#615) sit unshipped — cloud code had no automated path to production.

## How it works

- **`test` job** runs lint + the full Jest suite on ubuntu-22.04 (the OpenSSL-3 runner the mongo test binary needs).
- **`deploy` job** `needs: test`, so a failing suite blocks the deploy even on a direct push to master. It installs the `b4a` CLI, writes `~/.back4app/netrc` from a secret, generates a minimal `.parse.local`, and runs `b4a deploy production`.

Auth was validated non-interactively against the live app with a read-only `b4a releases production` (lists v98) — confirming the netrc format and minimal `.parse.local` resolve the app without the interactive `b4a add` flow.

## ⚠️ Required before this works: set two repo secrets

Settings → Secrets and variables → Actions:

- `B4A_ACCOUNT_KEY` — Back4App account key (Dashboard → avatar → Account Keys)
- `B4A_PRODUCTION_APP_ID` — production app's Application ID

The workflow fails fast with a clear error if either is missing.

## Note

Consider adding branch protection so master requires the `test` check (the four dead required checks — Codacy/codecov/Snyk — were removed earlier; the working Jest check isn't currently required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)