### PR TITLE
fix: preserve collection-time surveyingUser during offline sync

### DIFF
--- a/_tests_/integration/offline.test.js
+++ b/_tests_/integration/offline.test.js
@@ -16,6 +16,12 @@ const findVitals = async (marker) => {
   return query.first();
 };
 
+const findSurveyData = async (marker) => {
+  const query = new Parse.Query('SurveyData');
+  query.equalTo('testMarker', marker);
+  return query.first();
+};
+
 describe('offline uploader client linking', () => {
   it('links an offline supplementary form to an already-synced client', async () => {
     // The client (person) exists online already — the everyday follow-up
@@ -100,5 +106,118 @@ describe('offline uploader client linking', () => {
     const client = vitals.get('client');
     expect(client).toBeDefined();
     expect(client.get('objectIdOffline')).toEqual('PatientID-offline-123');
+  });
+});
+
+describe('offline uploader surveyor attribution', () => {
+  // Records store who collected them at collection time; the account that
+  // happens to press "sync" must not be stamped over the whole batch.
+  const syncerMetadata = {
+    surveyingUser: 'syncer@puente.org',
+    surveyingOrganization: 'Puente',
+    parseUser: 'syncer-parse-id',
+    appVersion: '9.9.9-sync',
+    phoneOS: 'android',
+  };
+
+  it('keeps the collection-time surveyingUser on resident forms', async () => {
+    await cloudFunctions.uploadOfflineForms({
+      residentForms: [
+        {
+          parseClass: 'SurveyData',
+          parseUser: 'undefined',
+          localObject: {
+            objectId: 'PatientID-attribution-1',
+            fname: 'Attributed',
+            lname: 'Person',
+            surveyingUser: 'collector@puente.org',
+            surveyingOrganization: 'Puente',
+            appVersion: '1.2.3',
+            phoneOS: 'ios',
+            testMarker: 'attribution-resident',
+          },
+        },
+      ],
+      households: [],
+      assetForms: [],
+      assetSupplementaryForms: [],
+      residentSupplementaryForms: [],
+      metadata: syncerMetadata,
+    });
+
+    const person = await findSurveyData('attribution-resident');
+    expect(person).toBeDefined();
+    expect(person.get('surveyingUser')).toEqual('collector@puente.org');
+    expect(person.get('appVersion')).toEqual('1.2.3');
+    expect(person.get('phoneOS')).toEqual('ios');
+  });
+
+  it('keeps the collection-time surveyingUser on supplementary forms', async () => {
+    const parent = await cloudFunctions.postObjectsToClass({
+      parseClass: 'SurveyData',
+      parseUser: 'undefined',
+      localObject: {
+        fname: 'Attribution',
+        lname: 'Parent',
+        surveyingOrganization: 'Puente',
+      },
+    });
+
+    await cloudFunctions.uploadOfflineForms({
+      residentForms: [],
+      households: [],
+      assetForms: [],
+      assetSupplementaryForms: [],
+      residentSupplementaryForms: [
+        {
+          parseClass: 'Vitals',
+          parseParentClass: 'SurveyData',
+          parseParentClassID: parent.id,
+          parseUser: 'undefined',
+          localObject: {
+            heartRate: '65',
+            surveyingUser: 'collector@puente.org',
+            surveyingOrganization: 'Puente',
+            testMarker: 'attribution-supplementary',
+          },
+        },
+      ],
+      metadata: syncerMetadata,
+    });
+
+    const vitals = await findVitals('attribution-supplementary');
+    expect(vitals).toBeDefined();
+    expect(vitals.get('surveyingUser')).toEqual('collector@puente.org');
+  });
+
+  it('falls back to sync-time metadata when the stored record lacks the field', async () => {
+    // Older app versions stored records without surveyingUser, and store
+    // appVersion as '' when unknown — metadata must still fill those gaps.
+    await cloudFunctions.uploadOfflineForms({
+      residentForms: [
+        {
+          parseClass: 'SurveyData',
+          parseUser: 'undefined',
+          localObject: {
+            objectId: 'PatientID-attribution-2',
+            fname: 'Legacy',
+            lname: 'Record',
+            appVersion: '',
+            testMarker: 'attribution-fallback',
+          },
+        },
+      ],
+      households: [],
+      assetForms: [],
+      assetSupplementaryForms: [],
+      residentSupplementaryForms: [],
+      metadata: syncerMetadata,
+    });
+
+    const person = await findSurveyData('attribution-fallback');
+    expect(person).toBeDefined();
+    expect(person.get('surveyingUser')).toEqual('syncer@puente.org');
+    expect(person.get('surveyingOrganization')).toEqual('Puente');
+    expect(person.get('appVersion')).toEqual('9.9.9-sync');
   });
 });

--- a/cloud/src/services/offline/offline.js
+++ b/cloud/src/services/offline/offline.js
@@ -1,14 +1,24 @@
 const { afterSurveyHouseholdHook, afterSupplementaryFormHook } = require('../post/hooks/afterSave');
 const post = require('../post/post');
 
+// Collection-time values (who surveyed, on which app/OS) must win over
+// sync-time metadata — whoever presses "sync" is often not the surveyor.
+// Metadata only fills fields the stored record left missing or empty.
+const mergeMetadataAsFallback = (localObject, metadata) => {
+  const merged = { ...localObject };
+  Object.entries(metadata || {}).forEach(([key, value]) => {
+    if (merged[key] === undefined || merged[key] === null || merged[key] === '') {
+      merged[key] = value;
+    }
+  });
+  return merged;
+};
+
 const postObjectsArray = (data, metadata) => {
   if (!data) return Promise.all([]);
   const promises = data.map(async (obj) => {
     const record = obj;
-    record.localObject = {
-      ...record.localObject,
-      ...metadata,
-    };
+    record.localObject = mergeMetadataAsFallback(record.localObject, metadata);
     const { localObject } = record;
     if (localObject.objectId && localObject.objectId.includes('PatientID-')) {
       localObject.objectIdOffline = localObject.objectId;
@@ -40,10 +50,7 @@ const postObjectsWithRelationshipsArray = async (data, metadata) => {
   if (!data) return Promise.all([]);
   const promises = data.map(async (obj) => {
     const record = obj;
-    record.localObject = {
-      ...record.localObject,
-      ...metadata,
-    };
+    record.localObject = mergeMetadataAsFallback(record.localObject, metadata);
     const { localObject } = record;
     if (record.parseParentClassID.includes('PatientID-')) {
       localObject.parseParentClassObjectIdOffline = record.parseParentClassID;
@@ -69,10 +76,7 @@ const postHouseholdArray = (data, metadata) => {
   const promises = data.map(async (obj) => {
     const record = obj;
 
-    record.localObject = {
-      ...record.localObject,
-      ...metadata,
-    };
+    record.localObject = mergeMetadataAsFallback(record.localObject, metadata);
     const { localObject } = record;
     if (localObject.objectId && localObject.objectId.includes('Household-')) {
       localObject.objectIdOffline = localObject.objectId;


### PR DESCRIPTION
## Problem
When a batch of offline records is synced, sync-time metadata (`surveyingUser`, `appVersion`, `phoneOS`, …) was spread **over** each stored record:

```js
record.localObject = { ...record.localObject, ...metadata };
```

So whoever pressed **sync** got stamped as the surveyor on every record in the batch — overwriting who actually collected the data. This is how records collected by one surveyor ended up attributed to a different account (seen during the Plan de Desarrollo / vitals investigation).

## Fix
Metadata is now merged as a **fallback only**: collection-time values win; metadata fills fields the stored record left missing or empty (`''` counts as empty because older app versions store `appVersion: ''`). Applied at all three call sites (resident forms, supplementary forms, households).

## Tests (TDD)
- `keeps the collection-time surveyingUser on resident forms` — **watched fail** (`Received: syncer@puente.org`) before the fix
- `keeps the collection-time surveyingUser on supplementary forms` — **watched fail** before the fix
- `falls back to sync-time metadata when the stored record lacks the field` — guards legacy records (no `surveyingUser`, empty `appVersion`)

Full suite: **32/32 green** locally against the parse-server + mongodb-memory-server harness.

## Deploy
Merging to master auto-deploys to Back4App production via the deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)