### PR TITLE
feat: idempotent offline uploads on objectIdOffline + response contract pin

### DIFF
--- a/_tests_/integration/offline.test.js
+++ b/_tests_/integration/offline.test.js
@@ -221,3 +221,127 @@ describe('offline uploader surveyor attribution', () => {
     expect(person.get('appVersion')).toEqual('9.9.9-sync');
   });
 });
+
+describe('offline upload response contract', () => {
+  // The mobile app treats any payload missing one of these five arrays as a
+  // failed sync and keeps its local queue (puente-reactnative-collect
+  // modules/offline/post). Changing this shape strands field devices in
+  // permanent retry — this test is the server half of that contract.
+  it('success payload carries all five categories as arrays', async () => {
+    const result = await cloudFunctions.uploadOfflineForms({
+      residentForms: [],
+      households: [],
+      assetForms: [],
+      assetSupplementaryForms: [],
+      residentSupplementaryForms: [],
+      metadata,
+    });
+
+    ['residentForms', 'residentSupplementaryForms', 'households',
+      'assetForms', 'assetSupplementaryForms'].forEach((key) => {
+      expect(Array.isArray(result[key])).toBe(true);
+    });
+  });
+});
+
+describe('offline upload idempotency', () => {
+  // A batch that partially fails leaves the whole queue on-device; the retry
+  // re-sends records that already saved. Re-syncing the same offline id must
+  // not create a duplicate.
+  const emptyBatch = () => ({
+    residentForms: [],
+    households: [],
+    assetForms: [],
+    assetSupplementaryForms: [],
+    residentSupplementaryForms: [],
+    metadata,
+  });
+
+  const countByMarker = async (parseClass, marker) => {
+    const query = new Parse.Query(parseClass);
+    query.equalTo('testMarker', marker);
+    return query.count();
+  };
+
+  it('re-syncing a resident form with the same offline id does not duplicate it', async () => {
+    const batch = () => ({
+      ...emptyBatch(),
+      residentForms: [{
+        parseClass: 'SurveyData',
+        parseUser: 'undefined',
+        localObject: {
+          objectId: 'PatientID-idem-1',
+          fname: 'Idem',
+          lname: 'Potent',
+          surveyingOrganization: 'Puente',
+          testMarker: 'idem-resident',
+        },
+      }],
+    });
+
+    await cloudFunctions.uploadOfflineForms(batch());
+    await cloudFunctions.uploadOfflineForms(batch());
+
+    expect(await countByMarker('SurveyData', 'idem-resident')).toEqual(1);
+  });
+
+  it('re-syncing a household with the same offline id does not duplicate it', async () => {
+    const batch = () => ({
+      ...emptyBatch(),
+      households: [{
+        parseClass: 'Household',
+        parseUser: 'undefined',
+        localObject: {
+          objectId: 'Household-idem-1',
+          latitude: 18.5,
+          testMarker: 'idem-household',
+        },
+      }],
+    });
+
+    await cloudFunctions.uploadOfflineForms(batch());
+    await cloudFunctions.uploadOfflineForms(batch());
+
+    expect(await countByMarker('Household', 'idem-household')).toEqual(1);
+  });
+
+  it('accepts SupID- local ids on supplementary forms: strips to objectIdOffline, links, and dedupes', async () => {
+    // Supplementary offline records carry no local id today; the mobile app
+    // will start stamping SupID-… ids so retries can dedupe. The server must
+    // handle them the same way it handles PatientID-/AssetID- ids.
+    const parent = await cloudFunctions.postObjectsToClass({
+      parseClass: 'SurveyData',
+      parseUser: 'undefined',
+      localObject: {
+        fname: 'Idem',
+        lname: 'Parent',
+        surveyingOrganization: 'Puente',
+      },
+    });
+
+    const batch = () => ({
+      ...emptyBatch(),
+      residentSupplementaryForms: [{
+        parseClass: 'Vitals',
+        parseParentClass: 'SurveyData',
+        parseParentClassID: parent.id,
+        parseUser: 'undefined',
+        localObject: {
+          objectId: 'SupID-idem-1',
+          heartRate: '75',
+          surveyingOrganization: 'Puente',
+          testMarker: 'idem-sup',
+        },
+      }],
+    });
+
+    await cloudFunctions.uploadOfflineForms(batch());
+    await cloudFunctions.uploadOfflineForms(batch());
+
+    expect(await countByMarker('Vitals', 'idem-sup')).toEqual(1);
+    const vitals = await findVitals('idem-sup');
+    expect(vitals.get('objectIdOffline')).toEqual('SupID-idem-1');
+    expect(vitals.get('client')).toBeDefined();
+    expect(vitals.get('client').id).toEqual(parent.id);
+  });
+});

--- a/cloud/src/services/offline/offline.js
+++ b/cloud/src/services/offline/offline.js
@@ -14,6 +14,16 @@ const mergeMetadataAsFallback = (localObject, metadata) => {
   return merged;
 };
 
+// A partially-failed batch stays queued on the device in full, so a retry
+// re-sends records that already saved. The offline id (objectIdOffline) is
+// the idempotency key: if a record with it already exists, return that
+// record instead of creating a duplicate.
+const findExistingOfflineRecord = (parseClass, objectIdOffline) => {
+  const query = new Parse.Query(parseClass);
+  query.equalTo('objectIdOffline', objectIdOffline);
+  return query.first({ useMasterKey: true });
+};
+
 const postObjectsArray = (data, metadata) => {
   if (!data) return Promise.all([]);
   const promises = data.map(async (obj) => {
@@ -33,6 +43,13 @@ const postObjectsArray = (data, metadata) => {
     if (localObject.objectId && localObject.objectId.includes('AssetID-')) {
       localObject.objectIdOffline = localObject.objectId;
       delete localObject.objectId;
+    }
+
+    if (localObject.objectIdOffline) {
+      const existing = await findExistingOfflineRecord(
+        record.parseClass, localObject.objectIdOffline,
+      );
+      if (existing) return existing;
     }
 
     return post.postObjectFactory('post', record);
@@ -59,6 +76,21 @@ const postObjectsWithRelationshipsArray = async (data, metadata) => {
       localObject.parseParentClassObjectIdOffline = record.parseParentClassID;
     }
 
+    // Supplementary forms stamped with a SupID-… local id get the same
+    // treatment as PatientID-/AssetID- records: the local id becomes
+    // objectIdOffline (Parse rejects unknown objectIds) and dedupes retries.
+    if (localObject.objectId && localObject.objectId.includes('SupID-')) {
+      localObject.objectIdOffline = localObject.objectId;
+      delete localObject.objectId;
+    }
+
+    if (localObject.objectIdOffline) {
+      const existing = await findExistingOfflineRecord(
+        record.parseClass, localObject.objectIdOffline,
+      );
+      if (existing) return existing;
+    }
+
     return post.postObjectFactory('post-relationship', record);
   });
 
@@ -82,6 +114,14 @@ const postHouseholdArray = (data, metadata) => {
       localObject.objectIdOffline = localObject.objectId;
       delete localObject.objectId;
     }
+
+    if (localObject.objectIdOffline) {
+      const existing = await findExistingOfflineRecord(
+        record.parseClass, localObject.objectIdOffline,
+      );
+      if (existing) return existing;
+    }
+
     return post.postObjectFactory('post', record);
   });
 


### PR DESCRIPTION
Follow-ups from the PR #603 (mobile) review.

## 1. Retry idempotency on `objectIdOffline`
A partially-failed batch stays queued on-device in full (by design — the mobile app now fails closed), so a retry re-sends records that already saved. `objectIdOffline` is now the idempotency key at all three upload paths:

- resident forms (`PatientID-…`), asset forms (`AssetID-…`), households (`Household-…`): if a record with the same `objectIdOffline` exists, it's returned instead of re-created
- supplementary forms: no local id exists today, but `SupID-…` ids are now stripped to `objectIdOffline` and deduped — the mobile app can start stamping them without another server deploy (today a stamped id would make Parse reject the save outright)

## 2. Response contract pin
The mobile app treats any `uploadOfflineForms` payload missing one of the five category arrays as a failed sync and keeps its local queue. New test pins that success responses always carry all five — a server-side shape change now breaks CI here instead of stranding field devices in permanent retry.

## Tests (TDD)
- resident duplicate: **watched red** (2 records) → green (1)
- household duplicate: **watched red** (2 records) → green (1)
- SupID supplementary: **watched red** (0 records — Parse rejects unknown objectId) → green (1, linked to client, id preserved in `objectIdOffline`)
- contract pin: green pin

Full suite: **36/36** against the local parse-server + mongodb harness. Lint clean.

Known limitation: two identical records inside the *same* batch still race past the existence check (Promise.all); cross-batch retries — the actual failure mode — are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)